### PR TITLE
refactor:TableSet连表时deepcopy(self)

### DIFF
--- a/smartsql.py
+++ b/smartsql.py
@@ -77,10 +77,10 @@ class TableSet(object):
         self._on = None
 
     def __mul__(self, obj):
-        return self._add_join("JOIN", obj)
+        return copy.deepcopy(self)._add_join("JOIN", obj)
 
     def __add__(self, obj):
-        return self._add_join("LEFT JOIN", obj)
+        return copy.deepcopy(self)._add_join("LEFT JOIN", obj)
 
     @property
     def sql(self):


### PR DESCRIPTION
保证(ts_base \* T.foo)后ts_base的状态不被改变

close #1 
